### PR TITLE
allow frontend testing from remote hosts

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -22,7 +22,7 @@
 
     let routesets = [];
 
-    let endpoint = "http://localhost:8080/"
+    let endpoint = "http://" + window.location.hostname + ":8080/"
     if (window.location.host.includes("bgp.exposed")){
         endpoint = window.location.protocol+"//"+window.location.host+"/api/"
     }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,5 +3,8 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [svelte()]
+  plugins: [svelte()],
+  server: {
+    host: true
+  }
 })


### PR DESCRIPTION
Currently the frontend assumes it is running on localhost. This removes that assumption so you can do dev on a VM and access from your laptop (my normal workflow).